### PR TITLE
Update `Home` page and `Getting Started` page

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                 <div class="w-5/6 md:w-3/5 ">
                     <h1 class="font-normal text-center mb-4">What's The Catch?</h1>
                     <div class="w-full text-left bg-grey-lightest py-6 px-6">
-                        There is no catch! The TurtlePay&reg; platform provided through our public APIs is free to use. All of the code published in the TurtlePay&reg; repositories is open source and you're free to use it as long as you adhere to the licensing terms. We don't charge a thing for using any of our services or code. The only fee you'll pay is the standard TurtleCoin&reg; network transaction fee-per-byte!
+                        There is no catch! The TurtlePay&reg; platform provided through our public APIs is free to use. All of the code published in the TurtlePay&reg; repositories is open source and you're free to use it as long as you adhere to the licensing terms. We don't charge a thing for using any of our services or code. The only fee you'll pay is the TurtleCoin&reg; network transaction fee-per-byte!
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                 <div class="w-5/6 md:w-3/5 ">
                     <h1 class="font-normal text-center mb-4">What's The Catch?</h1>
                     <div class="w-full text-left bg-grey-lightest py-6 px-6">
-                        There is no catch! The TurtlePay&reg; platform provided through our public APIs is free to use. All of the code published in the TurtlePay&reg; repositories is open source and you're free to use it as long as you adhere to the licensing terms. We don't charge a thing for using any of our services or code. The only fee you'll pay is the standard TurtleCoin&reg; network transaction fee of 0.10 TRTL per transaction!
+                        There is no catch! The TurtlePay&reg; platform provided through our public APIs is free to use. All of the code published in the TurtlePay&reg; repositories is open source and you're free to use it as long as you adhere to the licensing terms. We don't charge a thing for using any of our services or code. The only fee you'll pay is the standard TurtleCoin&reg; network transaction fee-per-byte!
                     </div>
                 </div>
             </div>
@@ -101,7 +101,7 @@
                     <a href="https://facebook.com/TurtlePay" target="_blank"><i class="fab fa-facebook fa-3x mx-4 text-grey-darker"></i></a> 
                     <a href="https://twitter.com/TurtlePay" target="_blank"><i class="fab fa-twitter fa-3x mx-4 text-grey-darker"></i></a>
                     <br /><br />
-                    Copyright © 2018-2019 TurtlePay&reg; Development Team. The source code is licensed under AGPL-3.0.
+                    Copyright © 2018-2020 TurtlePay&reg; Development Team. The source code is licensed under AGPL-3.0.
                 </div>
             </div>
         </section>

--- a/start.html
+++ b/start.html
@@ -156,7 +156,7 @@
                     <a href="https://facebook.com/TurtlePay" target="_blank"><i class="fab fa-facebook fa-3x mx-4 text-grey-darker"></i></a> 
                     <a href="https://twitter.com/TurtlePay" target="_blank"><i class="fab fa-twitter fa-3x mx-4 text-grey-darker"></i></a>
                     <br /><br />
-                    Copyright © 2018-2019 TurtlePay&reg; Development Team. The source code is licensed under AGPL-3.0.
+                    Copyright © 2018-2020 TurtlePay&reg; Development Team. The source code is licensed under AGPL-3.0.
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Update year in copyright section and change the standard TurtleCoin fees to the new fee-per-byte.